### PR TITLE
Fix wrong parameter in function call

### DIFF
--- a/servers/features/authentication/jwt.md
+++ b/servers/features/authentication/jwt.md
@@ -56,7 +56,7 @@ val jwtRealm = environment.config.property("jwt.realm").getString()
 install(Authentication) {
     jwt {
         realm = jwtRealm
-        verifier(makeJwtVerifier(jwtIssuer, jwtIssuer))
+        verifier(makeJwtVerifier(jwtIssuer, jwtAudience))
         validate { credential ->
             if (credential.payload.audience.contains(jwtAudience)) JWTPrincipal(credential.payload) else null
         }


### PR DESCRIPTION
The 2nd parameter of `makeJwtVerifier` should be `jwtAudience`, not `jwtIssuer`.